### PR TITLE
Add tests for index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,12 @@ This is my personal web developer portfolio built using HTML and CSS. More proje
 ## Live Site
 
 Hosted on GitHub Pages: https://vegadesigns.github.io/portfolio/
+
+## Running Tests
+
+Install dependencies and run `pytest` from the project root:
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@
       <ul>
         <li>
           <strong>Budget Tracker</strong> – A simple app to track income and expenses with localStorage support.<br />
-          <a href="https://vegadesigns.github.io/budget-tracker/" target="_blank">Live Demo</a> |
-          <a href="https://github.com/VegaDesigns/budget-tracker" target="_blank">GitHub Repo</a>
+          <a href="https://vegadesigns.github.io/budget-tracker/" target="_blank" rel="noopener noreferrer">Live Demo</a> |
+          <a href="https://github.com/VegaDesigns/budget-tracker" target="_blank" rel="noopener noreferrer">GitHub Repo</a>
         </li>
         
       </ul>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+beautifulsoup4

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+from bs4 import BeautifulSoup
+
+HTML_PATH = Path(__file__).resolve().parents[1] / "index.html"
+
+def load_soup():
+    html = HTML_PATH.read_text(encoding="utf-8")
+    return BeautifulSoup(html, "html.parser")
+
+def test_at_least_one_project_link_exists():
+    soup = load_soup()
+    heading = soup.find('h2', string=lambda x: x and 'Projects' in x)
+    assert heading, "Projects section heading not found"
+    section = heading.find_parent('section')
+    assert section, "Projects section not found"
+    links = section.find_all('a')
+    assert len(links) >= 1, "No project links found"
+
+def test_target_blank_has_noopener_noreferrer():
+    soup = load_soup()
+    for anchor in soup.find_all('a', target='_blank'):
+        rel = anchor.get('rel', [])
+        if isinstance(rel, str):
+            rel = rel.split()
+        assert 'noopener' in rel and 'noreferrer' in rel, f"Anchor {anchor} missing rel=\"noopener noreferrer\""


### PR DESCRIPTION
## Summary
- add automated tests for index.html using BeautifulSoup
- ensure external links use `rel="noopener noreferrer"`
- specify `pytest` and `beautifulsoup4` in requirements
- document how to run the tests in README

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement beautifulsoup4)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_685a2638e874832eb11ae073db83e622