### PR TITLE
Add noopener noreferrer to external links

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@
       <ul>
         <li>
           <strong>Budget Tracker</strong> – A simple app to track income and expenses with localStorage support.<br />
-          <a href="https://vegadesigns.github.io/budget-tracker/" target="_blank">Live Demo</a> |
-          <a href="https://github.com/VegaDesigns/budget-tracker" target="_blank">GitHub Repo</a>
+          <a href="https://vegadesigns.github.io/budget-tracker/" target="_blank" rel="noopener noreferrer">Live Demo</a> |
+          <a href="https://github.com/VegaDesigns/budget-tracker" target="_blank" rel="noopener noreferrer">GitHub Repo</a>
         </li>
         
       </ul>


### PR DESCRIPTION
## Summary
- ensure external links opened in a new tab use `rel="noopener noreferrer"`

## Testing
- `grep -n noopener -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_685a2630e8cc832ebe9f65a77d326ae4